### PR TITLE
Transformers upgrade hot fix

### DIFF
--- a/scripts/model/apply/bert.py
+++ b/scripts/model/apply/bert.py
@@ -109,7 +109,7 @@ def _predict(note_df,
                                                    p_dropout=init_params["p_dropout"],
                                                    use_bert_pooler=False if "use_bert_pooler" not in init_params else init_params["use_bert_pooler"],
                                                    random_state=init_params["random_state"]).to(args.device)
-    _ = model.load_state_dict(torch.load(f"{args.model}/model.pth", map_location=torch.device('cpu')))
+    _ = model.load_state_dict(torch.load(f"{args.model}/model.pth", map_location=torch.device('cpu')),strict=False)
     ## 
     _, predictions = model_bert.classification_evaluate_model(model=model,
                                                               dataset=dataset,

--- a/scripts/model/experiments/domain_distance.py
+++ b/scripts/model/experiments/domain_distance.py
@@ -668,7 +668,7 @@ def main():
                                                        use_bert_pooler=minit.get("use_bert_pooler",False),
                                                        checkpoint=minit["checkpoint"],
                                                        p_dropout=minit["settings"]["p_dropout"])
-            _ = model.load_state_dict(torch.load(f"{mpath}/model.pth",torch.device("cpu")))
+            _ = model.load_state_dict(torch.load(f"{mpath}/model.pth",torch.device("cpu")), strict=False)
             model = model.to(args.device)
             ## Encode Dataset
             dataset = bert_utils.ClassificationTokenDataset(tokens=tokens,

--- a/scripts/model/train/bert.py
+++ b/scripts/model/train/bert.py
@@ -582,7 +582,7 @@ def _run_bert(dataset_id,
                                                        use_bert_pooler=model_settings["use_bert_pooler"],
                                                        p_dropout=model_settings["p_dropout"],
                                                        random_state=random_state).to(device)
-        _ = model.load_state_dict(torch.load(f"{model_dir}/checkpoint-{task_id_opt}/model.pth"))
+        _ = model.load_state_dict(torch.load(f"{model_dir}/checkpoint-{task_id_opt}/model.pth"),  strict=False)
         ## Put Model into Evaluation Mode
         model.eval()    
         ## Iterate Through Datasets to Generate Final Predictions

--- a/stigma/api.py
+++ b/stigma/api.py
@@ -482,7 +482,7 @@ class StigmaBertModel(object):
                                                                                random_state=init_params["random_state"]).to(self._device)
         ## Load Weights
         print("[Initializing Model Weights]")
-        _ = self.model_dict["classifier"].load_state_dict(torch.load(f"{model}/model.pth", map_location=torch.device('cpu')))
+        _ = self.model_dict["classifier"].load_state_dict(torch.load(f"{model}/model.pth", map_location=torch.device('cpu')), strict=False)
     
     def predict(self,
                 text,


### PR DESCRIPTION
This will address the issue highlighted by #3, in which an update to the `transformers` python library causes `load_state_dict` to fail when loading BERT-style models which were trained using earlier versions of the library.